### PR TITLE
Fix bug 1371566: Support HTTPS environment variable for SSL settings

### DIFF
--- a/bin/deis-cli-install.sh
+++ b/bin/deis-cli-install.sh
@@ -2,10 +2,10 @@
 
 # included in the repo because it's only available over http from deis.io
 
-# install current version unless overridden by first command-line argument
 cd ~/docker
 
-VERSION=${1:-1.13.2}
+# install current version unless overridden by first command-line argument
+VERSION=${1:-1.13.3}
 
 if [[ -x ./deis ]]; then
   if [[ "$VERSION" == $(./deis version) ]]; then
@@ -21,7 +21,7 @@ set -e
 # determine from whence to download the installer
 PLATFORM=`uname | tr '[:upper:]' '[:lower:]'`
 DEIS_INSTALLER=${DEIS_INSTALLER:-deis-cli-$VERSION-$PLATFORM-amd64.run}
-DEIS_BASE_URL=${DEIS_BASE_URL:-https://s3-us-west-2.amazonaws.com/get-deis}
+DEIS_BASE_URL=${DEIS_BASE_URL:-https://getdeis.blob.core.windows.net/get-deis}
 INSTALLER_URL=$DEIS_BASE_URL/$DEIS_INSTALLER
 
 # download the installer archive to /tmp

--- a/nucleus/settings.py
+++ b/nucleus/settings.py
@@ -217,7 +217,9 @@ DEIS_DOMAIN = config('DEIS_DOMAIN', default=None)
 DEIS_RELEASE = config('DEIS_RELEASE', default=None)
 
 SSLIFY_DISABLE = config('DISABLE_SSL', default=DEBUG, cast=bool)
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+if not SSLIFY_DISABLE:
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 USE_X_FORWARDED_HOST = True
 RAVEN_CONFIG = {
     'dsn': config('SENTRY_DSN', None),

--- a/nucleus/wsgi.py
+++ b/nucleus/wsgi.py
@@ -9,12 +9,25 @@ https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
 import os
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'nucleus.settings')  # NOQA
 
+from django.core.handlers.wsgi import WSGIRequest
 from django.core.wsgi import get_wsgi_application
 
 from decouple import config
 
 
+IS_HTTPS = config('HTTPS', default='off') == 'on'
+
+
+class WSGIHTTPSRequest(WSGIRequest):
+    def _get_scheme(self):
+        if IS_HTTPS:
+            return 'https'
+
+        return super(WSGIHTTPSRequest, self)._get_scheme()
+
+
 application = get_wsgi_application()
+application.request_class = WSGIHTTPSRequest
 
 if config('SENTRY_DSN', None):
     from raven.contrib.django.raven_compat.middleware.wsgi import Sentry


### PR DESCRIPTION
Copy the way Bedrock does this. Required for HTTPS support in Deis Workflow clusters.