### PR TITLE
Enable ETag support

### DIFF
--- a/nucleus/settings.py
+++ b/nucleus/settings.py
@@ -113,6 +113,8 @@ USE_L10N = config('USE_L10N', default=True, cast=bool)
 
 USE_TZ = config('USE_TZ', default=True, cast=bool)
 
+USE_ETAGS = config('USE_ETAGS', default=True, cast=bool)
+
 STATIC_ROOT = config('STATIC_ROOT', default=os.path.join(BASE_DIR, 'static'))
 STATIC_URL = config('STATIC_URL', '/static/')
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'


### PR DESCRIPTION
The JSON data updater supports this now
so this will greatly reduce bytes transfered.