### PR TITLE
Use Django's SecurityMiddleware

### DIFF
--- a/nucleus/settings.py
+++ b/nucleus/settings.py
@@ -65,7 +65,7 @@ for app in config('EXTRA_APPS', default='', cast=Csv()):
     INSTALLED_APPS.append(app)
 
 MIDDLEWARE_CLASSES = (
-    'sslify.middleware.SSLifyMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'nucleus.base.middleware.HostnameMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -82,6 +82,17 @@ MIDDLEWARE_CLASSES = (
 ROOT_URLCONF = 'nucleus.urls'
 
 WSGI_APPLICATION = 'nucleus.wsgi.application'
+
+# legacy setting
+DISABLE_SSL = config('DISABLE_SSL', default=DEBUG, cast=bool)
+# SecurityMiddleware settings
+SECURE_HSTS_SECONDS = config('SECURE_HSTS_SECONDS', default='0', cast=int)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_BROWSER_XSS_FILTER = config('SECURE_BROWSER_XSS_FILTER', default=True, cast=bool)
+SECURE_CONTENT_TYPE_NOSNIFF = config('SECURE_CONTENT_TYPE_NOSNIFF', default=True, cast=bool)
+SECURE_SSL_REDIRECT = config('SECURE_SSL_REDIRECT', default=not DISABLE_SSL, cast=bool)
+if config('USE_SECURE_PROXY_HEADER', default=SECURE_SSL_REDIRECT, cast=bool):
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 
 # Database
@@ -217,10 +228,6 @@ HOSTNAME = platform.node()
 DEIS_APP = config('DEIS_APP', default=None)
 DEIS_DOMAIN = config('DEIS_DOMAIN', default=None)
 DEIS_RELEASE = config('DEIS_RELEASE', default=None)
-
-SSLIFY_DISABLE = config('DISABLE_SSL', default=DEBUG, cast=bool)
-if not SSLIFY_DISABLE:
-    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 USE_X_FORWARDED_HOST = True
 RAVEN_CONFIG = {

--- a/nucleus/wsgi.py
+++ b/nucleus/wsgi.py
@@ -15,7 +15,7 @@ from django.core.wsgi import get_wsgi_application
 from decouple import config
 
 
-IS_HTTPS = config('HTTPS', default='off') == 'on'
+IS_HTTPS = config('HTTPS', default='off', cast=bool)
 
 
 class WSGIHTTPSRequest(WSGIRequest):

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,8 +81,6 @@ dj-database-url==0.4.1 \
     --hash=sha256:7f4c78d2a090df8dfaf56d5d3ff7bbee17360436e4879558317e2314424864cd
 https://github.com/pmclanahan/django-synctool/archive/fix-dumpdata.tar.gz#egg=django-synctool==1.1.0 \
     --hash=sha256:cdb85d2932a9923206db9ef7172220bebf573fdf74ceaacfe2ea9c4957de778c
-django-sslify==0.2.7 \
-    --hash=sha256:f6bfd21048c7dfc95b39659a3da77775d6db1c1f7a745805ccc6c6138f783b6d
 Markdown==2.6.6 \
     --hash=sha256:9a292bb40d6d29abac8024887bcfc1159d7a32dc1d6f1f6e8d6d8e293666c504 \
     --hash=sha256:022239550fb4a84bcc3b3b42dff9a41efc56d773ef17c4f28016dd8f265c82d0


### PR DESCRIPTION
Remove django-sslify. Brings Nucleus in-line with the security practices on our other Django-based sites.