### PR TITLE
[fix #96] update frankfurt AWS deployment on stage branch commit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,22 @@ stage:
     - docker/bin/push2dockerhub.sh
     - bin/update-config.sh
 
+
+stage-aws:
+  tags:
+    - meao
+    - aws
+  only:
+    - stage
+  variables:
+    NAMESPACE: nucleus-stage
+    CLUSTER_NAME: frankfurt
+  script:
+    - docker/bin/build_images.sh
+    - docker/bin/push2dockerhub.sh
+    - bin/update-config.sh
+
+
 prod:
   tags:
     - meao


### PR DESCRIPTION
I believe this is blocked by mozmeao/nucleus-config#12 and mozmeao/nucleus-config#13, but is probably ready for a sanity check.