### PR TITLE
Move all-releases.json to use last-modified and if-modified-since headers

### DIFF
--- a/nucleus/rna/models.py
+++ b/nucleus/rna/models.py
@@ -19,14 +19,14 @@ class ReleaseManager(models.Manager):
         """Return all releases as a list of dicts"""
         return [r.to_dict() for r in self.prefetch_related('note_set').all()]
 
-    def recently_modified(self, days_ago=7, mod_date=None):
+    def recently_modified_list(self, days_ago=7, mod_date=None):
         if mod_date is None:
             mod_date = now() - timedelta(days=days_ago)
 
         query = self.filter(Q(modified__gte=mod_date) |
                             Q(note__modified__gte=mod_date) |
                             Q(fixed_note_set__modified__gte=mod_date))
-        return query.prefetch_related('note_set')
+        return [r.to_dict() for r in query.prefetch_related('note_set')]
 
 
 class Release(SaveToGithubModel):

--- a/nucleus/rna/tests/test_models.py
+++ b/nucleus/rna/tests/test_models.py
@@ -36,23 +36,26 @@ class TestReleaseQueries(TestCase):
 
     def test_recently_modified_release(self):
         """Should only return releases modified more recently than `days_ago`"""
-        query = Release.objects.recently_modified(days_ago=5)
-        assert self.r1 not in query
-        assert self.r2 not in query
-        assert self.r3 in query
+        data = Release.objects.recently_modified_list(days_ago=5)
+        versions = [o['version'] for o in data]
+        assert self.r1.version not in versions
+        assert self.r2.version not in versions
+        assert self.r3.version in versions
 
     def test_recently_modified_note(self):
         """Should also return releases with notes modified more recently than `days_ago`"""
         self.r1.note_set.create(note='The Dude minds, man')
-        query = Release.objects.recently_modified(days_ago=5)
-        assert self.r1 in query
-        assert self.r2 not in query
-        assert self.r3 in query
+        data = Release.objects.recently_modified_list(days_ago=5)
+        versions = [o['version'] for o in data]
+        assert self.r1.version in versions
+        assert self.r2.version not in versions
+        assert self.r3.version in versions
 
     def test_recently_modified_fixed_in_note(self):
         """Should also return releases with notes modified more recently than `days_ago`"""
         self.r2.fixed_note_set.create(note='The Dude minds, man')
-        query = Release.objects.recently_modified(days_ago=5)
-        assert self.r1 not in query
-        assert self.r2 in query
-        assert self.r3 in query
+        data = Release.objects.recently_modified_list(days_ago=5)
+        versions = [o['version'] for o in data]
+        assert self.r1.version not in versions
+        assert self.r2.version in versions
+        assert self.r3.version in versions

--- a/nucleus/rna/tests/test_views.py
+++ b/nucleus/rna/tests/test_views.py
@@ -1,16 +1,19 @@
 import json
 from datetime import timedelta
 
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
+from django.utils.http import http_date
 from django.utils.timezone import now
 
 from nucleus.rna.models import Release
+from nucleus.rna.views import export_json
 
 
 class TestExportJSON(TestCase):
     def setUp(self):
-        four_weeks_ago = now() - timedelta(days=28)
-        three_weeks_ago = now() - timedelta(days=21)
+        over_20_days = now() - timedelta(days=22)
+        over_30_days = now() - timedelta(days=32)
+        over_40_days = now() - timedelta(days=42)
         self.r1 = Release.objects.create(
             product='Firefox',
             channel='Nightly',
@@ -30,35 +33,45 @@ class TestExportJSON(TestCase):
             version='89.0a2',
             release_date=now(),
         )
-        self.r1.modified = four_weeks_ago
+        self.r1.modified = over_40_days
         self.r1.save(modified=False)
-        self.r2.modified = three_weeks_ago
+        self.r2.modified = over_30_days
         self.r2.save(modified=False)
+        self.r3.modified = over_20_days
+        self.r3.save(modified=False)
+        self.rf = RequestFactory()
 
     def test_recently_modified_release(self):
-        """Should only return releases modified more recently than 14 days ago"""
-        resp = self.client.get('/rna/all-releases.json')
+        """Should only return releases modified more recently than 30 days ago"""
+        resp = export_json(self.rf.get('/'))
         data = json.loads(resp.content)
         release_versions = [o['version'] for o in data]
         assert self.r1.version not in release_versions
         assert self.r2.version not in release_versions
         assert self.r3.version in release_versions
 
-    def test_last_modified_param(self):
+    def test_if_modified_since(self):
         """Should only return releases modified more recently than last-modified param"""
-        over_three_weeks_ago = now() - timedelta(days=22)
-        resp = self.client.get('/rna/all-releases.json',
-                               {'last-modified': over_three_weeks_ago.isoformat()})
+        over_30_days_ago = now() - timedelta(days=34)
+        header_date = http_date(over_30_days_ago.timestamp())
+        resp = export_json(self.rf.get('/', HTTP_IF_MODIFIED_SINCE=header_date))
         data = json.loads(resp.content)
         release_versions = [o['version'] for o in data]
         assert self.r1.version not in release_versions
         assert self.r2.version in release_versions
         assert self.r3.version in release_versions
 
-    def test_invalid_last_modified_param(self):
+    def test_if_modified_since_not_modified(self):
+        """Should return an empty list if nothing has been modified since"""
+        header_date = http_date(now().timestamp())
+        resp = export_json(self.rf.get('/', HTTP_IF_MODIFIED_SINCE=header_date))
+        data = json.loads(resp.content)
+        assert data == []
+
+    def test_invalid_if_modified_since_header(self):
         """Should go back to 14 day default if param is not ISO date"""
-        resp = self.client.get('/rna/all-releases.json',
-                               {'last-modified': 'this is our concern Dude'})
+        header_date = 'this is our concern Dude'
+        resp = export_json(self.rf.get('/', HTTP_IF_MODIFIED_SINCE=header_date))
         data = json.loads(resp.content)
         release_versions = [o['version'] for o in data]
         assert self.r1.version not in release_versions
@@ -68,7 +81,7 @@ class TestExportJSON(TestCase):
     def test_recently_modified_note(self):
         """Should also return releases with notes modified more recently than 14 days ago"""
         self.r1.note_set.create(note='The Dude minds, man')
-        resp = self.client.get('/rna/all-releases.json')
+        resp = export_json(self.rf.get('/'))
         data = json.loads(resp.content)
         release_versions = [o['version'] for o in data]
         assert self.r1.version in release_versions
@@ -78,7 +91,7 @@ class TestExportJSON(TestCase):
     def test_recently_modified_fixed_in_note(self):
         """Should also return releases with notes modified more recently than 14 days ago"""
         self.r2.fixed_note_set.create(note='The Dude minds, man')
-        resp = self.client.get('/rna/all-releases.json')
+        resp = export_json(self.rf.get('/'))
         data = json.loads(resp.content)
         release_versions = [o['version'] for o in data]
         assert self.r1.version not in release_versions


### PR DESCRIPTION
We can use these instead of a query param to follow HTTP and allow
Django to handle returning a 304 for us when nothing has been modified.
