### PR TITLE
Bug 1733207: Make unpublishing release notes more obvious

### DIFF
--- a/nucleus/rna/admin.py
+++ b/nucleus/rna/admin.py
@@ -37,11 +37,11 @@ class ReleaseAdminForm(forms.ModelForm):
 
     class Meta:
         model = models.Release
-        fields = '__all__'
+        fields = ('is_public', 'product', 'channel', 'version', 'release_date', 'text', 'bug_list', 'bug_search_url', 'system_requirements' )
 
 
 class ReleaseAdmin(admin.ModelAdmin):
-    actions = ['copy_releases', 'set_to_public']
+    actions = ['copy_releases', 'set_to_public', 'set_to_private']
     form = ReleaseAdminForm
     list_display = ('version', 'product', 'channel', 'is_public',
                     'release_date', 'text', 'url')
@@ -109,6 +109,12 @@ class ReleaseAdmin(admin.ModelAdmin):
             obj.is_public = True
             obj.save()
 
+    def set_to_private(self, request, queryset):
+        """ Set one or several releases to private """
+        # save them individually so that signals are sent
+        for obj in queryset:
+            obj.is_public = False
+            obj.save()
 
 admin.site.register(models.Note, NoteAdmin)
 admin.site.register(models.Release, ReleaseAdmin)

--- a/nucleus/rna/models.py
+++ b/nucleus/rna/models.py
@@ -42,7 +42,7 @@ class Release(SaveToGithubModel):
     version = models.CharField(max_length=255)
     release_date = models.DateTimeField()
     text = models.TextField(blank=True)
-    is_public = models.BooleanField(default=False)
+    is_public = models.BooleanField(default=False, help_text = "Note: If checked, these Release Notes will be visible on www.mozilla.org")
     bug_list = models.TextField(blank=True)
     bug_search_url = models.CharField(max_length=2000, blank=True)
     system_requirements = models.TextField(blank=True)


### PR DESCRIPTION
1/ Adds a new option to the admin listing to unpublish releases
2/ Put the is_public checkbox at the top with a note explaining what it does