### PR TITLE
631: Fix inviable dark-mode support + do micro Django upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,6 @@ check-requirements: .make.docker.pull
 compile-requirements: .make.docker.pull
 	${DC} run --rm compile-requirements
 
-install-local-python-deps:
-	pip install -r requirements/dev.txt
-
 ###############
 # For use in CI
 ###############

--- a/nucleus/rna/static/css/admin/unset_dark_mode.css
+++ b/nucleus/rna/static/css/admin/unset_dark_mode.css
@@ -1,0 +1,61 @@
+/* Deliberately designed to disable/ignore dark-mode 
+changes because they made the current UI unworkable:
+https://github.com/mozilla/nucleus/issues/631 
+
+This is heavy-handed, because it basically clones the light-mode CSS and tells 
+the browser to use that for dark mode, but it works for now. Note that 
+Django 4.0 seems to have a cleaner way to handle dark-mode tweaks. */
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary: #79aec8;
+    --secondary: #417690;
+    --accent: #f5dd5d;
+    --primary-fg: #fff;
+  
+    --body-fg: #333;
+    --body-bg: #fff;
+    --body-quiet-color: #666;
+    --body-loud-color: #000;
+  
+    --header-color: #ffc;
+    --header-branding-color: var(--accent);
+    --header-bg: var(--secondary);
+    --header-link-color: var(--primary-fg);
+  
+    --breadcrumbs-fg: #c4dce8;
+    --breadcrumbs-link-fg: var(--body-bg);
+    --breadcrumbs-bg: var(--primary);
+  
+    --link-fg: #447e9b;
+    --link-hover-color: #036;
+    --link-selected-fg: #5b80b2;
+  
+    --hairline-color: #e8e8e8;
+    --border-color: #ccc;
+  
+    --error-fg: #ba2121;
+  
+    --message-success-bg: #dfd;
+    --message-warning-bg: #ffc;
+    --message-error-bg: #ffefef;
+  
+    --darkened-bg: #f8f8f8; /* A bit darker than --body-bg */
+    --selected-bg: #e4e4e4; /* E.g. selected table cells */
+    --selected-row: #ffc;
+  
+    --button-fg: #fff;
+    --button-bg: var(--primary);
+    --button-hover-bg: #609ab6;
+    --default-button-bg: var(--secondary);
+    --default-button-hover-bg: #205067;
+    --close-button-bg: #888; /* Previously #bbb, contrast 1.92 */
+    --close-button-hover-bg: #747474;
+    --delete-button-bg: #ba2121;
+    --delete-button-hover-bg: #a41515;
+  
+    --object-tools-fg: var(--button-fg);
+    --object-tools-bg: var(--close-button-bg);
+    --object-tools-hover-bg: var(--close-button-hover-bg);
+  }
+}

--- a/nucleus/rna/templates/admin/base_site.html
+++ b/nucleus/rna/templates/admin/base_site.html
@@ -1,0 +1,6 @@
+{% extends "admin/base_site.html" %}
+{% load static %}    
+
+{% block extrastyle %}
+    <link rel="stylesheet" type="text/css" href="{% static "css/admin/unset_dark_mode.css" %}">
+{% endblock %}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,9 +6,9 @@
 # $ make compile-requirements
 #
 -r prod.txt
-attrs==21.4.0 \
-    --hash=sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4 \
-    --hash=sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd
+attrs==22.1.0 \
+    --hash=sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6 \
+    --hash=sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
     # via pytest
 black==22.3.0 \
     --hash=sha256:06f9d8846f2340dfac80ceb20200ea5d1b3f181dd0556b47af4e8e0b24fa0a6b \

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -12,7 +12,7 @@ django-jinja==2.10.0
 django-pagedown==2.2.1
 django-session-csrf==0.7.1
 django-watchman==1.3.0
-Django==3.2.14
+Django==3.2.15
 djangorestframework==3.13.1
 entrypoints==0.4
 gunicorn==20.1.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-# SHA1:7add08f45347e025b3fbd9e25f04cb6571aeb4da
+# SHA1:9491989dae3cb1c5720fb9d777c94df76a487323
 # Please recompile requirements inside the Docker image, not on your local, host machine.
 #
 # To do this, just use the following from your host:
@@ -138,9 +138,9 @@ dj-database-url==0.5.0 \
     --hash=sha256:4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163 \
     --hash=sha256:851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9
     # via -r requirements/prod.in
-django==3.2.14 \
-    --hash=sha256:677182ba8b5b285a4e072f3ac17ceee6aff1b5ce77fd173cc5b6a2d3dc022fcf \
-    --hash=sha256:a8681e098fa60f7c33a4b628d6fcd3fe983a0939ff1301ecacac21d0b38bad56
+django==3.2.15 \
+    --hash=sha256:115baf5049d5cf4163e43492cdc7139c306ed6d451e7d3571fe9612903903713 \
+    --hash=sha256:f71934b1a822f14a86c9ac9634053689279cd04ae69cb6ade4a59471b886582b
     # via
     #   -r requirements/prod.in
     #   django-allow-cidr
@@ -442,9 +442,9 @@ python-decouple==3.6 \
     --hash=sha256:2838cdf77a5cf127d7e8b339ce14c25bceb3af3e674e039d4901ba16359968c7 \
     --hash=sha256:6cf502dc963a5c642ea5ead069847df3d916a6420cad5599185de6bab11d8c2e
     # via -r requirements/prod.in
-pytz==2022.1 \
-    --hash=sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7 \
-    --hash=sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c
+pytz==2022.2.1 \
+    --hash=sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197 \
+    --hash=sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5
     # via
     #   django
     #   djangorestframework
@@ -475,9 +475,9 @@ sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
     --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d
     # via django
-urllib3==1.26.10 \
-    --hash=sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec \
-    --hash=sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6
+urllib3==1.26.11 \
+    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
+    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
     # via
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
This changeset:

1) Adds an extra Admin stylesheet to negate dark mode. Dark mode is nice, but it was clashing with some of the UI widgets, making the RNA admin unusable and requiring users to flip to light mode to do their work - see #631. This change means we always show light-mode colours, even when dark mode is active.

2) Upgrades to Django 3.2.15, fixing a security gap

3) Removes a duplicated command in the Makefile

#Resolves #631 
#Resolves #638 

### Screenshots

**Before, with dark mode enabled at a browser level**
<img width="1155" alt="Screenshot 2022-08-19 at 14 21 20" src="https://user-images.githubusercontent.com/101457/185628513-eca1b5d9-d9d4-47f2-a76b-9b9e7e0da85f.png">
<img width="1074" alt="Screenshot 2022-08-19 at 14 21 08" src="https://user-images.githubusercontent.com/101457/185628533-924fa7f0-90c6-4613-9e19-1e30e0ea0940.png">




**After, with dark mode still enabled at a browser level**

<img width="1203" alt="Screenshot 2022-08-19 at 14 20 50" src="https://user-images.githubusercontent.com/101457/185628729-c6dbcb1f-508d-4967-a5df-1b4c4cae5ba5.png">
<img width="1199" alt="Screenshot 2022-08-19 at 14 20 56" src="https://user-images.githubusercontent.com/101457/185628747-07511414-41fe-482b-bcb1-c4715b798a40.png">


### To test

* Pull the branch
* `make run-shell` to get a bash shell in Docker, then `./manage.py createsuperuser` to make one
* `make run` and then log in to the admin 
* Ensure you have a dark theme enabled in FF and/or Dark Mode selected on your computer
* Confirm that all admin views / sections are rendered in the lighter palette. You can use dev tools' style inspector to confirm that an `unset_dark_mode.css` file is being included.