### PR TITLE
Add validation to Notes admin to require a period or exclamation mark as the final character

### DIFF
--- a/nucleus/rna/tests/test_admin.py
+++ b/nucleus/rna/tests/test_admin.py
@@ -1,0 +1,100 @@
+from django.test import override_settings
+
+import pytest
+
+from nucleus.rna.admin import NoteAdminForm
+
+
+@pytest.mark.parametrize(
+    "note_markdown, expected_error",
+    (
+        (
+            "Test with no trailing punctuation",
+            "Notes must end with appropriate punctuation. Allowed marks are: . or !",
+        ),
+        (
+            "Test note with a [URL][1] in it and no closing punctuation\r\n\r\n\r\n  [1]: http://example.com/test",
+            "Notes must end with appropriate punctuation. Allowed marks are: . or !",
+        ),
+        (
+            (
+                "Multi-line test note with a [URL][1] in it.\r\n"
+                "And DOES have terminal punctuation on this middle line.\r\n"
+                "But not on this final line, with a second [URL][2] in it\r\n\r\n\r\n"
+                "  [1]: http://example.com/test\r\n"
+                "  [2]: http://example.com/test2"
+            ),
+            "Notes must end with appropriate punctuation. Allowed marks are: . or !",
+        ),
+        (
+            "Test with disallowed trailing punctuation?",
+            "Notes must end with appropriate punctuation. Allowed marks are: . or !",
+        ),
+        (
+            "Test with allowed trailing punctuation!",
+            None,
+        ),
+        (
+            "Test note with a [URL][1] in it and closing punctuation.\r\n\r\n\r\n  [1]: http://example.com/test",
+            None,
+        ),
+        (
+            "Multi-line test note with a [URL][1] in it.\r\nAnd closing punctuation.\r\n\r\n\r\n  [1]: http://example.com/test",
+            None,
+        ),
+        (
+            (
+                "Multi-line test note with a [URL][1] in it.\r\n"
+                "And no terminal punctuation on this middle line\r\n"
+                "AND with a second [URL][2] in it.\r\n\r\n\r\n"
+                "  [1]: http://example.com/test\r\n"
+                "  [2]: http://example.com/test2"
+            ),
+            None,
+        ),
+    ),
+)
+def test_noteadminform_clean_note(note_markdown, expected_error):
+    form_data = {
+        "note": note_markdown,
+        "bug": 123132,
+        "sort_num": 0,
+    }
+    form = NoteAdminForm(data=form_data)
+    was_valid = form.is_valid()
+    if expected_error:
+        assert not was_valid
+        assert form.errors["note"] == [expected_error]
+    else:
+        assert was_valid, "Expected form to be valid"
+
+
+@pytest.mark.parametrize(
+    "note_markdown, expected_error, settings_to_patch",
+    (
+        (
+            "Test with no trailing punctuation will be allowed with setting disabled",
+            None,
+            {"RNA_NOTES_ENFORCE_CLOSING_PUNCTUATION": False},
+        ),
+        (
+            "Test with DISALLOWED trailing punctuation!",
+            "Notes must end with appropriate punctuation. Allowed marks are: ? or . or ¿",
+            {"RNA_NOTES_EXPECTED_CLOSING_PUNCTUATION": ["?", ".", "¿"]},
+        ),
+    ),
+)
+def test_noteadminform_clean_note__amendable_via_settings(note_markdown, expected_error, settings_to_patch):
+    form_data = {
+        "note": note_markdown,
+        "bug": 123132,
+        "sort_num": 0,
+    }
+    with override_settings(**settings_to_patch):
+        form = NoteAdminForm(data=form_data)
+        was_valid = form.is_valid()
+        if expected_error:
+            assert not was_valid
+            assert form.errors["note"] == [expected_error]
+        else:
+            assert was_valid, "Expected form to be valid"

--- a/nucleus/settings.py
+++ b/nucleus/settings.py
@@ -339,3 +339,15 @@ if OIDC_ENABLE:
     OIDC_CREATE_USER = config("OIDC_CREATE_USER", default=False, cast=bool)
     MIDDLEWARE = MIDDLEWARE + ("mozilla_django_oidc.middleware.SessionRefresh",)
     LOGIN_REDIRECT_URL = "/admin/"
+
+
+RNA_NOTES_ENFORCE_CLOSING_PUNCTUATION = config(
+    "RNA_NOTES_ENFORCE_CLOSING_PUNCTUATION",
+    default=True,
+    cast=bool,
+)
+RNA_NOTES_EXPECTED_CLOSING_PUNCTUATION = config(
+    "RNA_NOTES_EXPECTED_CLOSING_PUNCTUATION",
+    default=".,!",  # NB: , is not one of the expected values and never will be.
+    cast=Csv(str),
+)

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -1,4 +1,5 @@
 asn1crypto==1.5.1
+beautifulsoup4==4.11.1 
 chardet==4.0.0
 contextlib2==21.6.0
 dj-database-url==0.5.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,4 +1,4 @@
-# SHA1:9491989dae3cb1c5720fb9d777c94df76a487323
+# SHA1:e9405affe81f24dc2e86b218e99dd47e3547548a
 # Please recompile requirements inside the Docker image, not on your local, host machine.
 #
 # To do this, just use the following from your host:
@@ -12,6 +12,10 @@ asgiref==3.5.2 \
 asn1crypto==1.5.1 \
     --hash=sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c \
     --hash=sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67
+    # via -r requirements/prod.in
+beautifulsoup4==4.11.1 \
+    --hash=sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30 \
+    --hash=sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693
     # via -r requirements/prod.in
 blinker==1.5 \
     --hash=sha256:1eb563df6fdbc39eeddc177d953203f99f097e9bf0e2b8f9f3cf18b6ca425e36 \
@@ -95,9 +99,9 @@ chardet==4.0.0 \
     --hash=sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa \
     --hash=sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5
     # via -r requirements/prod.in
-charset-normalizer==2.1.0 \
-    --hash=sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5 \
-    --hash=sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413
+charset-normalizer==2.1.1 \
+    --hash=sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845 \
+    --hash=sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
     # via requests
 contextlib2==21.6.0 \
     --hash=sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f \
@@ -467,6 +471,10 @@ sentry-sdk==1.5.8 \
     --hash=sha256:32af1a57954576709242beb8c373b3dbde346ac6bd616921def29d68846fb8c3 \
     --hash=sha256:38fd16a92b5ef94203db3ece10e03bdaa291481dd7e00e77a148aa0302267d47
     # via -r requirements/prod.in
+soupsieve==2.3.2.post1 \
+    --hash=sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759 \
+    --hash=sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d
+    # via beautifulsoup4
 spinach==0.0.14 \
     --hash=sha256:072a10c8ee882b855a3c353701521384af9cf00f7b956114cdf4a94d13579d21 \
     --hash=sha256:ae5be29b3ebe91afa1cefbc2e575ecf73891cd45460fea4c8680604d8672ab14
@@ -475,9 +483,9 @@ sqlparse==0.4.2 \
     --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
     --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d
     # via django
-urllib3==1.26.11 \
-    --hash=sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc \
-    --hash=sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
+urllib3==1.26.12 \
+    --hash=sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e \
+    --hash=sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
     # via
     #   requests
     #   sentry-sdk


### PR DESCRIPTION
This was requested in #639 as part of making it easier to standardise Release Notes content.

If an entry lacks an accepted terminating punctuation mark, we'll show a validation error in the admin and the author can try again:

<img width="878" alt="Screenshot 2022-08-24 at 14 29 57" src="https://user-images.githubusercontent.com/101457/186464298-a75509da-724a-49ac-92df-e41cf8814a41.png">

By default the behaviour is on, but can be easily overridden via env vars (via `nucleus-config`)

The list of allowed characters can also be amended via environment vars.

Fixes #639


### To test
* pull this branch
* `make shell` then`./manage.py createsuperuser` then exit the shell
* `make run` 
* log in to the admin at http://localhost:8000/admin/ 
* Browse to RNA > Notes and add a new note, leaving off punctuation, attempting to save, etc. 