### PR TITLE
Add edge-case validation for notes field with image as last thing

### DIFF
--- a/nucleus/rna/tests/test_admin.py
+++ b/nucleus/rna/tests/test_admin.py
@@ -52,6 +52,28 @@ from nucleus.rna.admin import NoteAdminForm
             ),
             None,
         ),
+        (
+            (
+                "This is a multi-line note with a [URL][1] in it\r\n\r\n"
+                "and it finishes with an image which understandably\r\n\r\n"
+                "has no terminal punctuation after it:\r\n\r\n"
+                "![an image][2]\r\n\r\n"
+                "[1]: http://example.com/test\r\n"
+                "[2]: http://example.com/image.png\r\n"
+            ),
+            None,
+        ),
+        (
+            (
+                "This is a multi-line note with a [URL][1] in it\r\n\r\n"
+                "and it finishes with some text AFTER an image, which\r\n\r\n"
+                "has no terminal punctuation after it:\r\n\r\n"
+                "![an image][2] and some blurb with no punctuation\r\n\r\n"
+                "[1]: http://example.com/test\r\n"
+                "[2]: http://example.com/image.png\r\n"
+            ),
+            "Notes must end with appropriate punctuation. Allowed marks are: . or !",
+        ),
     ),
 )
 def test_noteadminform_clean_note(note_markdown, expected_error):

--- a/nucleus/rna/tests/test_admin.py
+++ b/nucleus/rna/tests/test_admin.py
@@ -18,8 +18,8 @@ from nucleus.rna.admin import NoteAdminForm
         ),
         (
             (
-                "Multi-line test note with a [URL][1] in it.\r\n"
-                "And DOES have terminal punctuation on this middle line.\r\n"
+                "Multi-line test note with a [URL][1] in it.\r\n\r\n"
+                "And DOES have terminal punctuation on this middle line.\r\n\r\n"
                 "But not on this final line, with a second [URL][2] in it\r\n\r\n\r\n"
                 "  [1]: http://example.com/test\r\n"
                 "  [2]: http://example.com/test2"
@@ -44,8 +44,8 @@ from nucleus.rna.admin import NoteAdminForm
         ),
         (
             (
-                "Multi-line test note with a [URL][1] in it.\r\n"
-                "And no terminal punctuation on this middle line\r\n"
+                "Multi-line test note with a [URL][1] in it.\r\n\r\n"
+                "And no terminal punctuation on this middle line\r\n\r\n"
                 "AND with a second [URL][2] in it.\r\n\r\n\r\n"
                 "  [1]: http://example.com/test\r\n"
                 "  [2]: http://example.com/test2"


### PR DESCRIPTION
As raised in [a comment on #639](https://github.com/mozilla/nucleus/issues/639#issuecomment-1226713651), the new validation for Notes fields is tripped up if the Note in question has an image as its final element. This changeset adds logic to handle and tolerate that situation

<img width="1329" alt="Screenshot 2022-08-25 at 16 08 33" src="https://user-images.githubusercontent.com/101457/186714651-2eb49e8c-b4f4-4ea4-bc26-601fdfaace2b.png">
