### PR TITLE
Fix double pop-up when adding a new Note to a Release

### DIFF
--- a/nucleus/rna/templates/admin/rna/release/change_form.html
+++ b/nucleus/rna/templates/admin/rna/release/change_form.html
@@ -7,8 +7,8 @@
 <div id="note-table" data-releaseid="{{original.id}}"></div>
 <p>
   <input name="add-releasenote" id="add-releasenote" type="hidden">
-  <a href="/admin/rna/note/?t=id" class="related-lookup" id="lookup_add-releasenote" onclick="return showRelatedObjectLookupPopup(this);" title="Find a Note"></a>
-  <a href="/admin/rna/note/add/?releases={{original.id}}" class="related-lookup" style="width:16px; height:16px; background-image: url({% static 'admin/img/icon-addlink.svg' %});" onclick="return showAddAnotherPopup(this);" id="add_add-releasenote" title="Add a New Note"></a>
+  <a href="/admin/rna/note/?t=id" class="related-lookup" id="lookup_add-releasenote" title="Find a Note"></a>
+  <a href="/admin/rna/note/add/?releases={{original.id}}" class="related-lookup" style="width:16px; height:16px; background-image: url({% static 'admin/img/icon-addlink.svg' %});" id="add_add-releasenote" title="Add a New Note"></a>
 </p>
 <script type="text/javascript" src="{% static 'js/jquery-2.1.1.min.js' %}"></script>
 <script type="text/javascript" src="{% static 'js/mori/mori.js' %}"></script>


### PR DESCRIPTION
Previously, using the ➕  icon to add a Note (via a popup) to a Release triggerred _two_ pop-up windows (one a partial-page popup and the other a whole-page popup). 

This looks like a regression that slipped in as Django amended its admin popup behaviour. 

The fix appears to simply be to let Django's own event handlers drive the popups, and to remove the explicit calls to them from our own change form

Resolves #777 

Tested manually locally - will re-test when it's on Dev.

<img width="970" alt="Screenshot 2023-11-16 at 22 06 28" src="https://github.com/mozilla/nucleus/assets/101457/ba6ed24f-4f5d-4304-99b9-a7aefc2346b8">
