### PR TITLE
Tighten up auth to make API not anonymous-read

### DIFF
--- a/nucleus/settings.py
+++ b/nucleus/settings.py
@@ -204,7 +204,7 @@ REST_FRAMEWORK = {
     "DEFAULT_MODEL_SERIALIZER_CLASS": "nucleus.rna.serializers.HyperlinkedModelSerializerWithPkField",
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
-    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly",),
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.DjangoModelPermissions",),
     "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework.authentication.SessionAuthentication",),
 }
 


### PR DESCRIPTION
This will stop someone doing drive-by data siphoning (even though the data is also in the release-notes repo...) while also still allowing the small amount of JS that uses the /rna/notes route to still work. (Manually checked)


<img width="611" alt="Screenshot 2023-12-08 at 17 22 09" src="https://github.com/mozilla/nucleus/assets/101457/419ba6d4-5d28-49c5-866a-90c1ab2f8e95">
