### PR TITLE
Update docker compose to use v2 syntax, fixing GHAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,46 +6,46 @@ The publication platform for Mozilla's marketing websites.
 Docker for development
 ----------------------
 
-Make sure you have [docker](https://www.docker.com/products/docker-desktop) and 
-[docker-compose](https://github.com/docker/compose). After those are setup and running
+Make sure you have [docker](https://www.docker.com/products/docker-desktop) and
+[docker compose](https://github.com/docker/compose). After those are setup and running
 you can use the following commands:
 
 ```bash
-$ # This file must exist and you can customize environment variables for local dev in it
-$ touch .env
-$ # this pulls our latest builds from the docker hub.
-$ # it's optional but will speed up your builds considerably.
-$ docker-compose pull
-$ # get the site up and running
-$ docker-compose up web
+# This file must exist and you can customize environment variables for local dev in it
+touch .env
+# this pulls our latest builds from the docker hub.
+# it's optional but will speed up your builds considerably.
+docker compose pull
+# get the site up and running
+docker compose up web
 ```
 
 If you've made changes to the `Dockerfile` or the `requirements/*.txt` files you'll need to rebuild
 the image to run the app and tests:
 
 ```bash
-$ docker-compose build web
+docker compose build web
 ```
 
-Then to run the app you run the `docker-compose up web` command again, or for running tests against your local changes you run:
+Then to run the app you run the `docker compose up web` command again, or for running tests against your local changes you run:
 
 ```bash
-$ docker-compose run --rm test
+docker compose run --rm test
 ```
 
 We use pytest for running tests. So if you'd like to craft your own pytest command to run individual test files or something
 you can do so by passing in a command to the above:
 
 ```bash
-$ docker-compose run --rm test py.test nucleus/base/tests.py
+docker compose run --rm test py.test nucleus/base/tests.py
 ```
 
 And if you need to debug a running container, you can open another terminal to your nucleus code and run the following:
 
 ```bash
-$ docker-compose exec web bash
-$ # or
-$ docker-compose exec web python manage.py shell
+docker compose exec web bash
+# or
+docker compose exec web python manage.py shell
 ```
 
 Managing Python dependencies
@@ -58,7 +58,7 @@ If you add a new Python dependency (e.g. to `requirements/prod.in` or `requireme
 addition to our requirements files by running:
 
 ```bash
-$ make compile-requirements
+make compile-requirements
 ```
 
 and committing any changes that are made. Please re-build your docker image and test it with `make build test` to be sure the dependency
@@ -69,7 +69,7 @@ Similarly, if you *upgrade* a pinned dependency in an `*.in` file, run `make com
 To check for stale Python dependencies (basically `pip list -o` but in the Docker container):
 
 ```bash
-$ make check-requirements
+make check-requirements
 ```
 
 Install Python requirements locally
@@ -78,7 +78,7 @@ Install Python requirements locally
 Ideally, do this in a virtual environment (eg a `venv` or `virtualenv`)
 
 ```bash
-$ make install-local-python-deps
+make install-local-python-deps
 ```
 
 Docker for deploying to production
@@ -89,16 +89,16 @@ Docker for deploying to production
 3. Run the image:
 
 ```bash
-$ docker run --env-file env -p 80:8000 mozilla/nucleus
+docker run --env-file env -p 80:8000 mozilla/nucleus
 ```
 
 Heroku
 ------
+
 1. heroku create
 2. heroku config:set DEBUG=False ALLOWED_HOSTS=<foobar>.herokuapp.com, SECRET_KEY=something_secret
    DATABASE_URL gets populated by heroku once you setup a database.
 3. git push heroku master
-
 
 NewRelic Monitoring
 -------------------
@@ -106,17 +106,15 @@ NewRelic Monitoring
 A newrelic.ini file is already included. To enable NewRelic monitoring
 add two environment variables:
 
- - NEW_RELIC_LICENSE_KEY
- - NEW_RELIC_APP_NAME
+- NEW_RELIC_LICENSE_KEY
+- NEW_RELIC_APP_NAME
 
 See the [full list of supported environment variables](https://docs.newrelic.com/docs/agents/python-agent/installation-configuration/python-agent-configuration#environment-variables).
 
-
 ## Kubernetes
 
-https://github.com/mozmeao/nucleus-config/ has public examples of deployments in k8s clusters in AWS & GCP.
-
+<https://github.com/mozmeao/nucleus-config/> has public examples of deployments in k8s clusters in AWS & GCP.
 
 ## Gitlab CI/CD
 
-We have https://gitlab.com/mozmeao/nucleus/pipelines [set up as CI/CD for](https://gitlab.com/mozmeao/infra/blob/master/docs/gitlab_ci.md)  https://github.com/mozilla/nucleus via this [.gitlab-ci.yml](https://github.com/mozilla/nucleus/blob/gitlab/.gitlab-ci.yml), which [updates the config repo](https://github.com/mozilla/nucleus/blob/gitlab/bin/update-config.sh) triggering https://gitlab.com/mozmeao/nucleus/pipelines configured by [.gitlab-ci.yml in the config repo](https://github.com/mozilla/nucleus-config/blob/master/.gitlab-ci.yml).
+We have <https://gitlab.com/mozmeao/nucleus/pipelines> [set up as CI/CD for](https://gitlab.com/mozmeao/infra/blob/master/docs/gitlab_ci.md)  <https://github.com/mozilla/nucleus> via this [.gitlab-ci.yml](https://github.com/mozilla/nucleus/blob/gitlab/.gitlab-ci.yml), which [updates the config repo](https://github.com/mozilla/nucleus/blob/gitlab/bin/update-config.sh) triggering <https://gitlab.com/mozmeao/nucleus/pipelines> configured by [.gitlab-ci.yml in the config repo](https://github.com/mozilla/nucleus-config/blob/master/.gitlab-ci.yml).

--- a/bin/dc.sh
+++ b/bin/dc.sh
@@ -2,4 +2,4 @@
 
 # Set env vars used in docker-compose.yml and other scripts
 source docker/bin/set_git_env_vars.sh
-docker-compose "$@"
+docker compose "$@"


### PR DESCRIPTION
Switches to docker compose v2 syntax (no hyphen when calling `docker composez) because v1 syntax has lost support in `ubuntu-latest`