### PR TITLE
add GCP token file to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,4 @@
 .git
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
reference tickets: 
- https://mozilla-hub.atlassian.net/browse/SE-4414
- https://bugzilla.mozilla.org/show_bug.cgi?id=1959182